### PR TITLE
feat(*) pass stripped uri

### DIFF
--- a/kong/plugins/grpc-web/handler.lua
+++ b/kong/plugins/grpc-web/handler.lua
@@ -40,10 +40,17 @@ function grpc_web:access(conf)
     return kong_response_exit(200, "OK", CORS_HEADERS)
   end
 
+  local uri
+  if conf.pass_stripped_uri then
+    uri = ngx.var.upstream_uri
+    ngx.req.set_uri(uri)
+  else
+    uri = kong_request_get_path()
+  end
 
   local dec, err = deco.new(
     kong_request_get_header("Content-Type"),
-    kong_request_get_path(), conf.proto)
+    uri, conf.proto)
 
   if not dec then
     kong.log.err(err)

--- a/kong/plugins/grpc-web/schema.lua
+++ b/kong/plugins/grpc-web/schema.lua
@@ -11,6 +11,12 @@ return {
             default = nil,
           },
         },
+        {
+          pass_stripped_uri = {
+            type = "boolean",
+            required = false,
+          },
+        },
       },
     }, },
   },

--- a/spec/01-proxy_spec.lua
+++ b/spec/01-proxy_spec.lua
@@ -43,11 +43,26 @@ for _, strategy in helpers.each_strategy() do
         service = service1,
       })
 
+      local route2 = assert(bp.routes:insert {
+        protocols = { "http", "https" },
+        paths = { "/prefix" },
+        service = service1,
+      })
+
       assert(bp.plugins:insert {
         route = route1,
         name = "grpc-web",
         config = {
           proto = "spec/fixtures/grpc/hello.proto",
+        },
+      })
+
+      assert(bp.plugins:insert {
+        route = route2,
+        name = "grpc-web",
+        config = {
+          proto = "spec/fixtures/grpc/hello.proto",
+          pass_stripped_uri = true,
         },
       })
 
@@ -152,5 +167,16 @@ for _, strategy in helpers.each_strategy() do
       assert.is_nil(err)
     end)
 
+     test("Pass stripped URI", function()
+       local res, err = proxy_client:post("/prefix/hello.HelloService/SayHello", {
+         headers = {
+           ["Content-Type"] = "application/json",
+         },
+         body = cjson.encode{ greeting = "heya" },
+       })
+
+       assert.same({ reply = "hello heya" }, cjson.decode((res:read_body())))
+       assert.is_nil(err)
+     end)
  end)
 end


### PR DESCRIPTION
This plugin will, by design, pass the entire URI to the upstream gRPC service, even if a route is added with a path prefix component + `strip_path` set to true. This is in order to ensure there's no mismatch in the gRPC service/method name as defined in the protobuf and expected by clients/servers. However, if the client in use is able to manipulate the path, it might be useful to leverage Kong's path-based routing capabilities; this PR adds an option to the plugin -- `pass_stripped_path`, which defaults to true -- allowing such use case.

Fixes  #7 