### PR TITLE
feature - Add config option to set `Access-Control-Allow-Origin` header

### DIFF
--- a/kong/plugins/grpc-web/handler.lua
+++ b/kong/plugins/grpc-web/handler.lua
@@ -34,9 +34,10 @@ local CORS_HEADERS = {
 }
 
 function grpc_web:access(conf)
-  kong_response_set_header("Access-Control-Allow-Origin", "*")
+  kong_response_set_header("Access-Control-Allow-Origin", conf.allow_origin_header)
 
   if kong_request_get_method() == "OPTIONS" then
+    CORS_HEADERS["Access-Control-Allow-Origin"] = conf.allow_origin_header
     return kong_response_exit(200, "OK", CORS_HEADERS)
   end
 

--- a/kong/plugins/grpc-web/schema.lua
+++ b/kong/plugins/grpc-web/schema.lua
@@ -17,6 +17,13 @@ return {
             required = false,
           },
         },
+        {
+          allow_origin_header = {
+            type = "string",
+            required = false,
+            default = "*",
+          },
+        },
       },
     }, },
   },


### PR DESCRIPTION
This response header is hardcoded to `"*"` to pass the CORS settings of
the gRPC-Web library, but this value isn't allowed on requests "with
credentials", so it might be helpful to let the user to configure it.

Fix #11 