### PR TITLE
chore(*) prevent lua_pack from leaking to globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Table of Contents
 
+- [0.2.1](#021)
 - [0.2.0](#020)
+
+##  [0.2.1]
+
+> Released 2020/11/18
+
+- Prevent `lua_pack` from leaking to `string`
 
 ##  [0.2.0]
 
@@ -10,4 +17,6 @@
 causes the plugin to pass the stripped request path (see the `strip_path`
 Route attribute) to the upstream gRPC service.
 
+
+[0.2.1]: https://github.com/Kong/kong-plugin-grpc-web/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Kong/kong-plugin-grpc-web/compare/v0.1.1...v0.2.0

--- a/kong-plugin-grpc-web-0.2.1-0.rockspec
+++ b/kong-plugin-grpc-web-0.2.1-0.rockspec
@@ -1,12 +1,12 @@
 package = "kong-plugin-grpc-web"
 
-version = "0.2.0-0"
+version = "0.2.1-0"
 
 supported_platforms = {"linux", "macosx"}
 
 source = {
   url = "git+https://git@github.com/Kong/kong-plugin-grpc-web.git",
-  tag = "v0.2.0",
+  tag = "v0.2.1",
 }
 
 description = {

--- a/kong/plugins/grpc-web/deco.lua
+++ b/kong/plugins/grpc-web/deco.lua
@@ -1,14 +1,22 @@
 -- Copyright (c) Kong Inc. 2020
 
-require"lua_pack"
+local bpack, bunpack
+do
+  local string_pack = string.pack     -- luacheck: ignore
+  local string_unpack = string.unpack -- luacheck: ignore
+  package.loaded.lua_pack = nil
+  require "lua_pack"
+  bpack = string.pack                 -- luacheck: ignore
+  bunpack = string.unpack             -- luacheck: ignore
+  string.unpack = string_unpack       -- luacheck: ignore
+  string.pack = string_pack           -- luacheck: ignore
+end
+
 local cjson = require "cjson"
 local protoc = require "protoc"
 local pb = require "pb"
 
 local setmetatable = setmetatable
-
-local bpack=string.pack         -- luacheck: ignore string
-local bunpack=string.unpack     -- luacheck: ignore string
 
 local ngx = ngx
 local decode_base64 = ngx.decode_base64

--- a/kong/plugins/grpc-web/handler.lua
+++ b/kong/plugins/grpc-web/handler.lua
@@ -22,7 +22,7 @@ local kong_service_request_set_raw_body = kong.service.request.set_raw_body
 
 local grpc_web = {
   PRIORITY = 3,
-  VERSION = '0.2.0',
+  VERSION = '0.2.1',
 }
 
 


### PR DESCRIPTION
`lua_pack` is especially bad as it monkey patches the `string` in Lua. This means that whenever you require the `lua_pack` the `string` is modified. We don't want this to happen, thus we have this special construct there.

This also contains another commit `chore(*) release 0.2.1`.
